### PR TITLE
Add a getter for `containerId` field of `Instance`

### DIFF
--- a/localstack.go
+++ b/localstack.go
@@ -139,6 +139,11 @@ func (i *Instance) EndpointV2(service Service) string {
 	return ""
 }
 
+// ContainerId returns the deployed container's ID
+func (i *Instance) ContainerId() string {
+	return i.containerId
+}
+
 // Service represents an AWS service
 type Service string
 


### PR DESCRIPTION
This PR adds a getter for `containerId` field of the `Instance` struct. Currently, there is no way to retrieve the deployed container's ID.

In my case I needed the external port of the deployed container, which I cannot find out without the container's ID.