### PR TITLE
Add the ability to set Localstack environment and reconfigure an existing instance

### DIFF
--- a/localstack.go
+++ b/localstack.go
@@ -40,6 +40,7 @@ type Instance struct {
 	cli         internal.DockerClient
 	containerId string
 	portMapping map[Service]string
+	env         []string
 	version     string
 	fixedPort   bool
 }
@@ -53,6 +54,14 @@ type InstanceOption func(i *Instance)
 func WithVersion(version string) InstanceOption {
 	return func(i *Instance) {
 		i.version = version
+	}
+}
+
+// WithEnvironment configures the instance to use the selected
+// environment variables that will be passed to the spawned container.
+func WithEnvironment(env []string) InstanceOption {
+	return func(i *Instance) {
+		i.env = env
 	}
 }
 
@@ -240,6 +249,7 @@ func (i *Instance) startLocalstack(ctx context.Context) error {
 	resp, err := i.cli.ContainerCreate(ctx,
 		&container.Config{
 			Image: imageName,
+			Env:   i.env,
 		}, &container.HostConfig{
 			PortBindings: pm,
 			AutoRemove:   true,


### PR DESCRIPTION
Hi again. With this PR I suggest the following two features:
1. The ability to set the environment of a Localstack instance via `WithEnvironment` option. Currently, there is no way to pass environment variables to Localstack. There exist some useful environment variables that one may need: https://docs.localstack.cloud/localstack/configuration/

One such variable is `SERVICES`, which allows to start up only the selected Localstack services, instead of starting up all of them:
```
l, err := localstack.NewInstance(
	localstack.WithVersion("0.12.7"),
	localstack.WithEnvironment([]string{
		"SERVICES=ec2,dynamodb,s3",
	}),
)
```

2. The ability to reconfigure an already existing non-running instance. In my case, I reuse the same Localstack instance and regularly `Start` and `Stop` it. In between, I may want to apply different options, e.g., pass a different environment or even a different Localstack version.
```
l, _ := localstack.NewInstance(
	localstack.WithVersion("0.12.7"),
	localstack.WithEnvironment([]string{"SERVICES=ec2,dynamodb"}),
)


l.Start()

...

l.Stop()

l.Reconfigure(
	localstack.WithEnvironment([]string{"SERVICES=s3,dynamodb"}),
)

l.Start()

...
```