### PR TITLE
Add configurable logger

### DIFF
--- a/localstack.go
+++ b/localstack.go
@@ -27,13 +27,25 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/elgohr/go-localstack/internal"
 )
+
+var log = struct {
+	*logrus.Logger
+	sync.Mutex
+}{Logger: logrus.New()}
+
+// SetLogger sets the logger used by go-localstack.
+func SetLogger(logger *logrus.Logger) {
+	log.Lock()
+	log.Logger = logger
+	log.Unlock()
+}
 
 // Instance manages the localstack
 type Instance struct {
@@ -232,7 +244,7 @@ func (i *Instance) startLocalstack(ctx context.Context, services ...Service) err
 		}()
 
 		// for reading the load output
-		if _, err = io.Copy(log.StandardLogger().Out, reader); err != nil {
+		if _, err = io.Copy(log.Out, reader); err != nil {
 			return fmt.Errorf("localstack: %w", err)
 		}
 	}


### PR DESCRIPTION
This PR adds a configurable logger. It allows the users of the package to configure the logger that the package uses. Using new method called `SetLogger`, the users can pass down their own `logrus` logger.

In my case, I want to disable logging coming from `go-localstack`, but right now it's not trivial to do. With this PR that can easily be done with:
```
myLogger := &logrus.Logger{Out: io.Discard}
localstack.SetLogger(myLogger)
```
Apart from disabling the logger, there may be other use cases, such as customizing the log formatter or setting a specific log level.

I also added some tests, but I'm not sure if they're enough.